### PR TITLE
Refactor InventoryRepositoriesCommand into partial classes

### DIFF
--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
@@ -1,0 +1,50 @@
+﻿using Cake.Common.IO;
+
+namespace AZDOI.Commands;
+
+public partial class InventoryRepositoriesCommand
+{
+    private async Task<int> ProcessProjects(InventoryRepositoriesContext context)
+    {
+        logger.LogInformation("Cleaning directory {TargetPath}...", context.OutputDirectory);
+        cakeContext.CleanDirectory(context.OutputDirectory);
+        logger.LogInformation("Done cleaning directory {TargetPath}.", context.OutputDirectory);
+
+        var organization = new AzureDevOpsOrganization
+        {
+            Id = context.Settings.DevOpsOrg,
+            Name = context.Settings.DevOpsOrg,
+            Url = string.Empty,
+
+            Children = (await context.InvokeDevOpsClient(
+                (client, settings) => client.GetProjects(settings.DevOpsOrg, settings.IncludeProjects, settings.ExcludeProjects)
+                )).OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToArray()
+        };
+
+        foreach (var project in organization.Children)
+        {
+            var projectOutputDirectory = context.OutputDirectory.Combine(project.Name);
+
+            var repositories = await ProcessRepositories(
+            context with
+            {
+                OutputDirectory = context.OutputDirectory.Combine(project.Name)
+            },
+            project
+            );
+
+            await projectMarkdownService.WriteIndex
+                (projectOutputDirectory,
+                project with
+                {
+                    Children = repositories
+                }
+                );
+            logger.LogInformation("Markdown index created for project: {ProjectName}", project.Name);
+        }
+        await organizationMarkdownService.WriteIndex(context.OutputDirectory, organization);
+
+        logger.LogInformation("Done executing Inventory Repositories");
+        return 0;
+    }
+}

--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.Repositories.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.Repositories.cs
@@ -1,0 +1,77 @@
+﻿namespace AZDOI.Commands;
+
+public partial class InventoryRepositoriesCommand
+{
+    private async Task<AzureDevOpsRepository[]> ProcessRepositories(InventoryRepositoriesContext context, AzureDevOpsProject project)
+    {
+        using (logger.BeginScope(new { ProjectId = project.Id }))
+        {
+            logger.LogInformation("Project: {ProjectName}", project.Name);
+
+            var repositoriesDirectory = context.OutputDirectory.Combine("Repositories");
+
+            var repositories = await context.InvokeDevOpsClient((client, settings) =>
+                client.GetRepositories(settings.DevOpsOrg, project.Id, settings.IncludeRepositories, settings.ExcludeRepositories));
+
+            await repositoriesMarkdownService.WriteIndex(repositoriesDirectory, repositories);
+
+            foreach (var repo in repositories)
+            {
+                await ProcessRepository(context, project, repo, repositoriesDirectory);
+            }
+
+            return repositories;
+        }
+    }
+
+    private async Task ProcessRepository(InventoryRepositoriesContext context, AzureDevOpsProject project, AzureDevOpsRepository repo, DirectoryPath repositoriesDirectory)
+    {
+        using (logger.BeginScope(new { Repository = repo.Id }))
+        {
+            logger.LogInformation(" - Repository: {RepoName}", repo.Name);
+
+            if (!context.ShouldProcessRepoReadme(repo.Name))
+            {
+                logger.LogInformation("Excluded repository: {RepoName}", repo.Name);
+                return;
+            }
+
+            var readmeContent = string.Empty;
+            var repoOutputDirectory = repositoriesDirectory.Combine(repo.Name);
+            var (Exists, Length) = ((await context.InvokeDevOpsClient((client, settings) =>
+                client.GetRepositoryReadme(settings.DevOpsOrg, project.Id, repo.Id)))
+                ?.ReplaceLineEndings("\n")) is string c && c.Length > 0
+                ? (true, (readmeContent = c).Length)
+                : (false, 0);
+
+            await repositoryMarkdownService.WriteIndex(
+                repoOutputDirectory,
+                repo with
+                {
+                    ReadmeContent = readmeContent,
+                    Children = await context.InvokeDevOpsClient((client, settings) =>
+                    client.GetBranchesAsync(settings.DevOpsOrg, project.Id, repo.Id)),
+                    Tags = await context.InvokeDevOpsClient(
+                            async (client, settings) =>
+                                    await client.EnumerateTagsAsync(settings.DevOpsOrg, project.Id, repo.Id)
+                                        .SelectAwait(async tag => tag with
+                                        {
+                                            Message = (await client.GetAnnotatedTagsAsync(settings.DevOpsOrg, project.Id, repo.Id, tag.ObjectId))
+                                                        .FirstOrDefault()?.Message
+                                        }
+                                        )
+                                        .ToArrayAsync()
+                    )
+                }
+            );
+
+            logger.LogInformation("Markdown index created for repository: {RepoName}", repo.Name);
+
+            logger.LogInformation(
+                "README Exists: {Exists}, Length: {Length} characters",
+                Exists,
+                Length
+            );
+        }
+    }
+}

--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.cs
@@ -1,10 +1,9 @@
 ﻿using AZDOI.Commands.Settings;
 using AZDOI.Services.Markdown;
-using Cake.Common.IO;
 
 namespace AZDOI.Commands;
 
-public class InventoryRepositoriesCommand(
+public partial class InventoryRepositoriesCommand(
     ICakeContext cakeContext,
     AzureDevOpsClientHandler clientHandler,
     OrganizationMarkdownService organizationMarkdownService,
@@ -40,123 +39,6 @@ public class InventoryRepositoriesCommand(
         {
             logger.LogError(ex, "Failure during executing Inventory Repositories Command.");
             return 1;
-        }
-    }
-
-    private async Task<int> ProcessProjects(InventoryRepositoriesContext context)
-    {
-        logger.LogInformation("Cleaning directory {TargetPath}...", context.OutputDirectory);
-        cakeContext.CleanDirectory(context.OutputDirectory);
-        logger.LogInformation("Done cleaning directory {TargetPath}.", context.OutputDirectory);
-
-        var organization = new AzureDevOpsOrganization
-        {
-            Id = context.Settings.DevOpsOrg,
-            Name = context.Settings.DevOpsOrg,
-            Url = string.Empty,
-
-            Children = (await context.InvokeDevOpsClient(
-                (client, settings) => client.GetProjects(settings.DevOpsOrg, settings.IncludeProjects, settings.ExcludeProjects)
-                )).OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToArray()
-        };
-
-        foreach (var project in organization.Children)
-        {
-            var projectOutputDirectory = context.OutputDirectory.Combine(project.Name);
-
-            var repositories = await ProcessRepositories(
-            context with
-            {
-                OutputDirectory = context.OutputDirectory.Combine(project.Name)
-            },
-            project
-            );
-
-            await projectMarkdownService.WriteIndex
-                (projectOutputDirectory,
-                project with
-                {
-                    Children = repositories
-                }
-                );
-            logger.LogInformation("Markdown index created for project: {ProjectName}", project.Name);
-        }
-        await organizationMarkdownService.WriteIndex(context.OutputDirectory, organization);
-
-        logger.LogInformation("Done executing Inventory Repositories");
-        return 0;
-    }
-
-    private async Task<AzureDevOpsRepository[]> ProcessRepositories(InventoryRepositoriesContext context, AzureDevOpsProject project)
-    {
-        using (logger.BeginScope(new { ProjectId = project.Id }))
-        {
-            logger.LogInformation("Project: {ProjectName}", project.Name);
-
-            var repositoriesDirectory = context.OutputDirectory.Combine("Repositories");
-
-            var repositories = await context.InvokeDevOpsClient((client, settings) =>
-                client.GetRepositories(settings.DevOpsOrg, project.Id, settings.IncludeRepositories, settings.ExcludeRepositories));
-
-            await repositoriesMarkdownService.WriteIndex(repositoriesDirectory, repositories);
-
-            foreach (var repo in repositories)
-            {
-                await ProcessRepository(context, project, repo, repositoriesDirectory);
-            }
-
-            return repositories;
-        }
-    }
-
-    private async Task ProcessRepository(InventoryRepositoriesContext context, AzureDevOpsProject project, AzureDevOpsRepository repo, DirectoryPath repositoriesDirectory)
-    {
-        using (logger.BeginScope(new { Repository = repo.Id }))
-        {
-            logger.LogInformation(" - Repository: {RepoName}", repo.Name);
-
-            if (!context.ShouldProcessRepoReadme(repo.Name))
-            {
-                logger.LogInformation("Excluded repository: {RepoName}", repo.Name);
-                return;
-            }
-
-            var readmeContent = string.Empty;
-            var repoOutputDirectory = repositoriesDirectory.Combine(repo.Name);
-            var (Exists, Length) = ((await context.InvokeDevOpsClient((client, settings) =>
-                client.GetRepositoryReadme(settings.DevOpsOrg, project.Id, repo.Id)))
-                ?.ReplaceLineEndings("\n")) is string c && c.Length > 0
-                ? (true, (readmeContent = c).Length)
-                : (false, 0);
-
-            await repositoryMarkdownService.WriteIndex(
-                repoOutputDirectory,
-                repo with
-                {
-                    ReadmeContent = readmeContent,
-                    Children = await context.InvokeDevOpsClient((client, settings) =>
-                    client.GetBranchesAsync(settings.DevOpsOrg, project.Id, repo.Id)),
-                    Tags = await context.InvokeDevOpsClient(
-                            async (client, settings) =>
-                                    await client.EnumerateTagsAsync(settings.DevOpsOrg, project.Id, repo.Id)
-                                        .SelectAwait(async tag => tag with
-                                        {
-                                            Message = (await client.GetAnnotatedTagsAsync(settings.DevOpsOrg, project.Id, repo.Id, tag.ObjectId))
-                                                        .FirstOrDefault()?.Message
-                                        }
-                                        )
-                                        .ToArrayAsync()
-                    )
-                }
-            );
-
-            logger.LogInformation("Markdown index created for repository: {RepoName}", repo.Name);
-
-            logger.LogInformation(
-                "README Exists: {Exists}, Length: {Length} characters",
-                Exists,
-                Length
-            );
         }
     }
 }


### PR DESCRIPTION
### Refactor: Make InventoryRepositoriesCommand Partial

**Summary:**  
This PR splits `InventoryRepositoriesCommand` into three partial classes:
- **InventoryRepositoriesCommand.cs:** Contains the constructor and `ExecuteAsync`.
- **InventoryRepositoriesCommand.Projects.cs:** Handles the `ProcessProjects` logic.
- **InventoryRepositoriesCommand.Repositories.cs:** Manages the `ProcessRepositories` and `ProcessRepository` logic.

**Related Issue:**  
Fixes #5