### PR TITLE
Language Statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+AZDOI/src/site/theme/** linguist-vendored=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-AZDOI/src/site/theme/** linguist-vendored=true
+src/site/theme/** linguist-vendored=true


### PR DESCRIPTION
### Exclude Theme Folder from Language Statistics

**Summary:**  
This PR adds an entry to the `.gitattributes` file to mark the `AZDOI/src/site/theme` folder as vendored code. By doing so, GitHub's language statistics will exclude the pre-built JavaScript documentation from the overall language breakdown.

**Changes:**  
- Updated `.gitattributes` with: `src/site/theme/** linguist-vendored=true`

**Related Issue:**  
Fixes #6 