### PR TITLE
Added github action status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://dev.azure.com/AZDOI/AZDOI/_apis/build/status%2FWCOMAB.AZDOI?repoName=WCOMAB%2FAZDOI&branchName=main)](https://dev.azure.com/AZDOI/AZDOI/_build/latest?definitionId=2&repoName=WCOMAB%2FAZDOI&branchName=main)
+[![Build](https://github.com/WCOMAB/AZDOI/actions/workflows/build.yml/badge.svg)](https://github.com/WCOMAB/AZDOI/actions/workflows/build.yml)
 
 # AZDOI
 


### PR DESCRIPTION
### Add GitHub Actions Status Badge to README

**Summary:**  
This PR adds a GitHub Actions status badge to the README file. The badge displays the current CI build status, making it easier for contributors and maintainers to quickly assess the health of the project.

**Related Issue:**  
Fixes #12 