### PR TITLE
Fix: Handle spaces in Markdown links by adding angle brackets

### DIFF
--- a/src/AZDOI/Services/Markdown/MarkdownServiceBase.Children.cs
+++ b/src/AZDOI/Services/Markdown/MarkdownServiceBase.Children.cs
@@ -20,7 +20,7 @@ public abstract partial class MarkdownServiceBase<TValue>
             children
                 .Select(child =>
                     new KeyValuePair<string, string>(
-                        $"[{child.Name}]({urlSelector?.Invoke(child) ?? child.ChildUrl})",
+                        $"[{child.Name}](<{urlSelector?.Invoke(child) ?? child.ChildUrl}>)",
                         child.Description
                     )
                 )


### PR DESCRIPTION
**This PR Fixes bug #32** 

- Fixed Markdown link rendering issue by wrapping URLs in angle brackets (< >)
- Ensures links with spaces are properly formatted and clickable
- Affects MarkdownServiceBase.Children.cs in AZDOI/Services/Markdown/

**Summary**
Previously, links with spaces were breaking due to missing angle brackets. Now, all generated links are correctly wrapped, following Markdown standards.