### PR TITLE
Option to parallelize projects processing

### DIFF
--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
@@ -21,7 +21,9 @@ public partial class InventoryRepositoriesCommand
                 )).OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToArray()
         };
 
-        foreach (var project in organization.Children)
+        await context.ForEachAsync(
+        organization.Children,
+        async (project, ct) =>
         {
             var projectOutputDirectory = context.OutputDirectory.Combine(project.Name);
 
@@ -42,6 +44,7 @@ public partial class InventoryRepositoriesCommand
                 );
             logger.LogInformation("Markdown index created for project: {ProjectName}", project.Name);
         }
+        );
         await organizationMarkdownService.WriteIndex(context.OutputDirectory, organization);
 
         logger.LogInformation("Done executing Inventory Repositories");

--- a/src/AZDOI/Commands/Settings/AZDOISettings.cs
+++ b/src/AZDOI/Commands/Settings/AZDOISettings.cs
@@ -50,4 +50,8 @@ public class AZDOISettings(ICakeEnvironment environment) : CommandSettings, Serv
     [Description("Exclude specific repository README")]
     [CommandOption("--exclude-repository--readme")]
     public string[]? ExcludeRepositoriesReadme { get; set; }
+
+    [CommandOption("--run-in-parallel")]
+    [Description("Flag for if generation should be parallelized.")]
+    public bool RunInParallel { get; set; }
 }


### PR DESCRIPTION
### Enable Optional Parallel Project Processing

**Summary:**  
This PR introduces an option to process projects in parallel, improving execution speed when dealing with multiple projects. By default, projects are processed sequentially to maintain previous behavior. Users can now opt-in for parallel execution using the `--run-in-parallel` flag.  

**Changes:**  
- Added `--run-in-parallel` command option (`AZDOISettings.cs`) to toggle parallel processing.  
- Implemented `ForEachAsync` in `InventoryRepositoriesContextExtensions.cs`, allowing projects to be processed in parallel or sequentially.  
- Updated `ProcessProjects` in `InventoryRepositoriesCommand.Projects.cs` to use `context.ForEachAsync`.  
- Preserved existing structure while enabling dynamic execution control.  

**Related Issue:**  
Fixes #35 