### PR TITLE
added fallback value if readme is empty or null

### DIFF
--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
@@ -345,7 +345,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -359,7 +359,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -373,7 +373,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -382,7 +382,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -396,7 +396,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -410,7 +410,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat.verified.txt
@@ -469,7 +469,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -483,7 +483,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -497,7 +497,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output.verified.txt
@@ -469,7 +469,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -483,7 +483,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -497,7 +497,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   }

--- a/src/AZDOI.Tests/Unit/Commands/ValidateOrgAttributeTest.RunAsync_args=inventory,repositories,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/ValidateOrgAttributeTest.RunAsync_args=inventory,repositories,test-org,-output.verified.txt
@@ -469,7 +469,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -483,7 +483,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   },
@@ -497,7 +497,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 1524
+                        Length: 1554
                       }
                     ]
                   }

--- a/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=.verified.txt
@@ -1,0 +1,34 @@
+﻿---
+title: MyRepository
+summary: MyRepository
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# MyRepository
+
+## Repository Details
+
+|                                  |                                                                  |
+|----------------------------------|------------------------------------------------------------------|
+| Name                             | MyRepository                                                     |
+| Id                               | 1                                                                |
+| Size                             | 1.9 MB                                                           |
+| RemoteUrl                        | [myproject.com](https://myproject.com)                           |
+| WebUrl                           | [myproject.com](https://myproject.com)                           |
+| DefaultBranch                    | [main](https://myproject.com?version=GBmain)                     |
+
+## Branches
+
+| Branch                                                           | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [main](<https://myproject.com?version=GBmain>)                   | 1573218                          |
+
+## Tags
+
+| Tag                                                              | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [v0.1](<https://myproject.com?version=GTv0.1>)                   | 12345                            |
+
+## README
+
+> 🛑 Repository README missing

--- a/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=Readme Content.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=Readme Content.verified.txt
@@ -1,0 +1,34 @@
+﻿---
+title: MyRepository
+summary: MyRepository
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# MyRepository
+
+## Repository Details
+
+|                                  |                                                                  |
+|----------------------------------|------------------------------------------------------------------|
+| Name                             | MyRepository                                                     |
+| Id                               | 1                                                                |
+| Size                             | 1.9 MB                                                           |
+| RemoteUrl                        | [myproject.com](https://myproject.com)                           |
+| WebUrl                           | [myproject.com](https://myproject.com)                           |
+| DefaultBranch                    | [main](https://myproject.com?version=GBmain)                     |
+
+## Branches
+
+| Branch                                                           | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [main](<https://myproject.com?version=GBmain>)                   | 1573218                          |
+
+## Tags
+
+| Tag                                                              | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [v0.1](<https://myproject.com?version=GTv0.1>)                   | 12345                            |
+
+## README
+
+Readme Content

--- a/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=null.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.WriteIndex_ShouldWriteCorrectReadmeMarkdown_readmeContent=null.verified.txt
@@ -1,0 +1,34 @@
+﻿---
+title: MyRepository
+summary: MyRepository
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# MyRepository
+
+## Repository Details
+
+|                                  |                                                                  |
+|----------------------------------|------------------------------------------------------------------|
+| Name                             | MyRepository                                                     |
+| Id                               | 1                                                                |
+| Size                             | 1.9 MB                                                           |
+| RemoteUrl                        | [myproject.com](https://myproject.com)                           |
+| WebUrl                           | [myproject.com](https://myproject.com)                           |
+| DefaultBranch                    | [main](https://myproject.com?version=GBmain)                     |
+
+## Branches
+
+| Branch                                                           | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [main](<https://myproject.com?version=GBmain>)                   | 1573218                          |
+
+## Tags
+
+| Tag                                                              | ObjectId                         |
+|------------------------------------------------------------------|----------------------------------|
+| [v0.1](<https://myproject.com?version=GTv0.1>)                   | 12345                            |
+
+## README
+
+> 🛑 Repository README missing

--- a/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/RepositoryMarkdownServiceTests.cs
@@ -84,4 +84,49 @@ public class RepositoryMarkdownServiceTests
         // Then
         await Verify(result);
     }
+
+    [Theory]
+    [InlineData("Readme Content")]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task WriteIndex_ShouldWriteCorrectReadmeMarkdown(string? readmeContent)
+    {
+        // Given
+        var (fileSystem, service) = ServiceProviderFixture
+            .GetRequiredService<FakeFileSystem, RepositoryMarkdownService>();
+
+        var repository = new AzureDevOpsRepository
+        {
+            Id = "1",
+            Name = "MyRepository",
+            Size = 2000000,
+            RemoteUrl = "https://myproject.com",
+            WebUrl = "https://myproject.com",
+            ReadmeContent = readmeContent,
+            Url = "https://myproject.com",
+            DefaultBranch = "refs/heads/main",
+            Children = [
+                new AzureDevOpsRepositoryBranch
+                {
+                    Name = "main",
+                    ObjectId = "1573218",
+                    Url = "https://mybranch.com"
+                }
+            ],
+            Tags = [
+                new AzureDevOpsRepositoryTag
+                {
+                    Name = "refs/tags/v0.1",
+                    ObjectId = "12345",
+                    Url = "https://google.com"
+                }
+            ],
+        };
+
+        // When
+        var result = await service.TestWriteIndex(repository);
+
+        // Then
+        await Verify(result);
+    }
 }

--- a/src/AZDOI/Extensions/MarkdownExtensions.cs
+++ b/src/AZDOI/Extensions/MarkdownExtensions.cs
@@ -75,4 +75,9 @@ public static partial class MarkdownExtensions
 
         return $"{flooredValue.ToString("0.0", CultureInfo.InvariantCulture)} {units[unitIndex]}";
     }
+
+    public static string FallbackIfEmpty(this string value, string fallback)
+    {
+        return !string.IsNullOrWhiteSpace(value) ? value : fallback;
+    }
 }

--- a/src/AZDOI/Services/Markdown/RepositoryMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/RepositoryMarkdownService.cs
@@ -50,7 +50,7 @@ public class RepositoryMarkdownService(ICakeContext cakeContext, TimeProvider ti
            $$"""
             ## README
 
-            {{repository.ReadmeContent.IncreaseMarkdownHeaders()}}
+            {{repository.ReadmeContent.IncreaseMarkdownHeaders().FallbackIfEmpty("> 🛑 Repository README missing")}}
             """
        );
     }


### PR DESCRIPTION
### Output Indicator When README is Missing or Empty  

**Summary:**  
This PR improves the repository output by displaying a **clear indicator** when a README is missing or empty. Instead of leaving the section blank, the system now shows `> 🛑 Repository README missing`.  

**Changes:**  
- **Added an extension method `FallbackIfEmpty`**  
  - Allows returning a fallback value if a string is `null` or empty.  
  - Applied this method to handle missing/empty README content.  
- **Updated markdown output logic**  
  - Ensures that repositories with no README display a clear warning.  
- **Added a unit test for `FallbackIfEmpty`**  
  - Uses `[Theory]` to test different cases (`null`, `""`, and valid markdown).  

**Fixes:** #40   