### PR TITLE
move ShouldProcessRepoReadme to InventoryRepositoriesContext

### DIFF
--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.cs
@@ -20,17 +20,10 @@ public partial class InventoryRepositoriesCommand(
 
         try
         {
-            var shouldProcessRepoReadme = (
-                    settings.IncludeRepositoriesReadme,
-                    settings.ExcludeRepositoriesReadme
-                )
-                .ToFilterPredicate();
-
             var orgOutputDirectory = settings.OutputPath.Combine(settings.DevOpsOrg);
 
             var context = new InventoryRepositoriesContext(
                 settings,
-                shouldProcessRepoReadme,
                 orgOutputDirectory,
                 clientHandler
             );

--- a/src/AZDOI/Commands/InventoryRepositoriesContext.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesContext.cs
@@ -5,11 +5,17 @@ namespace AZDOI.Commands;
 
 public record InventoryRepositoriesContext(
     AZDOISettings Settings,
-    FilterHandler ShouldProcessRepoReadme,
     DirectoryPath OutputDirectory,
     AzureDevOpsClientHandler AzureDevOpsClientHandler
 )
 {
+    public FilterHandler ShouldProcessRepoReadme { get; init; } = 
+    (
+        Settings.IncludeRepositoriesReadme,
+        Settings.ExcludeRepositoriesReadme
+    )
+    .ToFilterPredicate();
+
     public async Task<TResult> InvokeDevOpsClient<TResult>(
         Func<AzureDevOpsClient, AZDOISettings, Task<TResult>> clientFunc)
     {


### PR DESCRIPTION
### Refactor: Move `ShouldProcessRepoReadme` to `InventoryRepositoriesContext`

**Summary:**  
This PR refactors the handling of `ShouldProcessRepoReadme` by moving it from `ExecuteAsync` into `InventoryRepositoriesContext`. This ensures that the property is derived directly from `AZDOISettings` and keeps `ExecuteAsync` cleaner.

**Changes:**  
- **Moved `ShouldProcessRepoReadme`** to `InventoryRepositoriesContext` as an `init` property.  
- **Removed redundant variable declaration** in `ExecuteAsync`.  
- **Now automatically computed** when `InventoryRepositoriesContext` is initialized.  

**Fixes** #43 
