### PR TITLE
Added PackageProjectUrl to .csproj

### DIFF
--- a/src/AZDOI/AZDOI.csproj
+++ b/src/AZDOI/AZDOI.csproj
@@ -10,6 +10,7 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>WCOM128x128_squares.png</PackageIcon>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://wcomab.github.io/AZDOI/</PackageProjectUrl>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR adds the PackageProjectUrl property to the AZDOI.csproj file. 

The PackageProjectUrl is now set to https://wcomab.github.io/AZDOI/, providing a direct link to the project's documentation and resources.

Fixes #42 