### PR TITLE
Refactor ProcessRepositories method in InventoryRepositoriesCommand

### DIFF
--- a/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
+++ b/src/AZDOI/Commands/InventoryRepositoriesCommand.Projects.cs
@@ -36,8 +36,6 @@ public partial class InventoryRepositoriesCommand
                                                     },
                                                     sourceProject
                                                 )
-                                                .OrderBy(_ => _.Name, StringComparer.OrdinalIgnoreCase)
-                                                .ToArrayAsync(ct)
                             };
 
                             await projectMarkdownService.WriteIndex(


### PR DESCRIPTION
- Changed the return type of ProcessRepositories from IAsyncEnumerable<AzureDevOpsRepository> to Task<AzureDevOpsRepository[]>.
- Updated the implementation to use ForEachAsync for processing repositories, ensuring they are ordered by name and converted to an array.
- Removed the yield return logic in favor of returning the complete array of repositories.
- fixes #56
