### PR TITLE
Mermaid diagram clickable repos

### DIFF
--- a/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
@@ -22,19 +22,27 @@ public class OrganizationMarkdownService(ICakeContext cakeContext, TimeProvider 
         await writer.WriteLineAsync("```mermaid");
         await writer.WriteLineAsync("graph TD");
         await writer.WriteLineAsync($"    Org_{organization.Id}({organization.Name})");
+        await writer.WriteLineAsync();
 
         foreach (var project in organization.Children)
         {
-            await writer.WriteLineAsync();
             await writer.WriteLineAsync($"    %% {project.Name} project");
             await writer.WriteLineAsync($"    subgraph Proj_{project.Id}[{project.Name}]");
+            await writer.WriteLineAsync("        direction TB");
+            await writer.WriteLineAsync($"        %% {project.Name} repos");
             await writer.WriteLineAsync($"        subgraph Repos_{project.Id}[Repositories]");
+
             foreach (var repo in project.Children)
             {
-                await writer.WriteLineAsync($"            Repo_{project.Id}_{repo.Id}[{repo.Name}]");
+                var nodeId = $"Repo_{project.Id}_{repo.Id}";
+                var repoUrl = $"https://dev.azure.com/{organization.Id}/{project.Name}/_git/{repo.Name}";
+
+                await writer.WriteLineAsync($"            {nodeId}[{repo.Name}]");
+                await writer.WriteLineAsync($"            click {nodeId} href \"{repoUrl}\" \"{repo.Name}\"");
             }
             await writer.WriteLineAsync("        end");
             await writer.WriteLineAsync("    end");
+            await writer.WriteLineAsync();
             await writer.WriteLineAsync($"    Org_{organization.Id} --> Proj_{project.Id}");
         }
 


### PR DESCRIPTION
### Add Clickable Links on Repository Nodes in Mermaid Diagram

**Summary:**  
This PR enhances the generated Mermaid diagram by making each repository node clickable. The clickable links direct users to the corresponding Azure DevOps repository page, improving navigation and usability of the documentation.

**Changes:**  
- Updated the Mermaid diagram generation to include the `click` directive for each repository node.
- Constructed the Azure DevOps repository URL using the pattern:  
  `https://dev.azure.com/{orgName}/{projectName}/_git/{repoName}`  
- Now, when a user hovers over a repository node in the diagram, they can click it to be redirected to the repo page on Azure DevOps.