### PR TITLE
Refactor Mermaid graph

### DIFF
--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
@@ -503,7 +503,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1660
+            Length: 2003
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -1110,7 +1110,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 2937
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
@@ -394,7 +394,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1287
+            Length: 1545
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository-readme=Test Repository.verified.txt
@@ -1187,7 +1187,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 3081
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
@@ -1104,7 +1104,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2014
+            Length: 2942
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -944,7 +944,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 2640
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -866,7 +866,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1241
+            Length: 1911
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
@@ -1175,7 +1175,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 3081
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
@@ -926,7 +926,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1727
+            Length: 2655
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
@@ -1193,7 +1193,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 3081
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
@@ -145,7 +145,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 724
+            Length: 729
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -629,7 +629,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1588
+            Length: 2049
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -463,7 +463,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1588
+            Length: 1752
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -478,7 +478,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 676
+            Length: 1266
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
@@ -712,7 +712,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1588
+            Length: 2193
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
@@ -712,7 +712,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1588
+            Length: 2193
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
@@ -1,0 +1,35 @@
+﻿---
+title: Test Organization
+summary: Test Organization
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# Test Organization DevOps Organization
+
+## Projects
+
+| Project                          | Description                      |
+|----------------------------------|----------------------------------|
+| [Test Project](<Test Project>)   |                                  |
+
+```mermaid
+graph TD
+    Org_Org1(Test Organization)
+
+    %% Test Project project
+    subgraph Proj_Proj1[Test Project]
+        direction TB
+        %% Test Project repos
+        subgraph Repos_Proj1[Repositories]
+            Repo_Proj1_1[MyRepository]
+            click Repo_Proj1_1 href "Test Project/Repositories/MyRepository/" "MyRepository"
+        end
+        %% Test Project pipelines
+        subgraph Pipelines_Proj1[Pipelines]
+            Pipeline_Proj1_1[MyPipeline.One]
+            click Pipeline_Proj1_1 href "Test Project/Build/Pipelines/MyPipeline.One/" "MyPipeline.One"
+        end
+    end
+
+    Org_Org1 --> Proj_Proj1
+```

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=None.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=None.verified.txt
@@ -1,0 +1,25 @@
+﻿---
+title: Test Organization
+summary: Test Organization
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# Test Organization DevOps Organization
+
+## Projects
+
+| Project                          | Description                      |
+|----------------------------------|----------------------------------|
+| [Test Project](<Test Project>)   |                                  |
+
+```mermaid
+graph TD
+    Org_Org1(Test Organization)
+
+    %% Test Project project
+    subgraph Proj_Proj1[Test Project]
+        direction TB
+    end
+
+    Org_Org1 --> Proj_Proj1
+```

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
@@ -1,0 +1,30 @@
+﻿---
+title: Test Organization
+summary: Test Organization
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# Test Organization DevOps Organization
+
+## Projects
+
+| Project                          | Description                      |
+|----------------------------------|----------------------------------|
+| [Test Project](<Test Project>)   |                                  |
+
+```mermaid
+graph TD
+    Org_Org1(Test Organization)
+
+    %% Test Project project
+    subgraph Proj_Proj1[Test Project]
+        direction TB
+        %% Test Project pipelines
+        subgraph Pipelines_Proj1[Pipelines]
+            Pipeline_Proj1_1[MyPipeline.One]
+            click Pipeline_Proj1_1 href "Test Project/Build/Pipelines/MyPipeline.One/" "MyPipeline.One"
+        end
+    end
+
+    Org_Org1 --> Proj_Proj1
+```

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Repositories.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Repositories.verified.txt
@@ -1,0 +1,30 @@
+﻿---
+title: Test Organization
+summary: Test Organization
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# Test Organization DevOps Organization
+
+## Projects
+
+| Project                          | Description                      |
+|----------------------------------|----------------------------------|
+| [Test Project](<Test Project>)   |                                  |
+
+```mermaid
+graph TD
+    Org_Org1(Test Organization)
+
+    %% Test Project project
+    subgraph Proj_Proj1[Test Project]
+        direction TB
+        %% Test Project repos
+        subgraph Repos_Proj1[Repositories]
+            Repo_Proj1_1[MyRepository]
+            click Repo_Proj1_1 href "Test Project/Repositories/MyRepository/" "MyRepository"
+        end
+    end
+
+    Org_Org1 --> Proj_Proj1
+```

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.cs
@@ -28,6 +28,70 @@ public class OrganizationMarkdownServiceTests
 
         // Then
         await Verify(result);
+    }
+
+    public class OrgMarkdownChildTypes
+    {
+        [Theory]
+        [InlineData(AzureDevOpsProjectChildTypes.None)]
+        [InlineData(AzureDevOpsProjectChildTypes.Repositories)]
+        [InlineData(AzureDevOpsProjectChildTypes.Pipelines)]
+        [InlineData(AzureDevOpsProjectChildTypes.All)]
+        public async Task WriteIndex_ShouldWriteExpectedMarkdownContent(AzureDevOpsProjectChildTypes childTypes)
+        {
+            var (fileSystem, service) = ServiceProviderFixture
+                .GetRequiredService<FakeFileSystem, OrganizationMarkdownService>();
+
+            var organization = new AzureDevOpsOrganization
+            {
+                Id = "Org1",
+                Name = "Test Organization",
+                Url = "",
+                Children =[
+                    new AzureDevOpsProject
+                    {
+                        Id = "Proj1",
+                        Name = "Test Project",
+                        ChildTypes = childTypes,
+                        Url = "https://myproject.com",
+                        Children = childTypes.HasFlag(AzureDevOpsProjectChildTypes.Repositories)
+                            ?
+                            [
+                                new AzureDevOpsRepository 
+                                {
+                                    Id = "1",
+                                    Name = "MyRepository",
+                                    Size = 2000000,
+                                    RemoteUrl = "https://myproject.com",
+                                    WebUrl = "https://myproject.com",
+                                    Url = "https://myproject.com"
+                                }
+                            ]
+                            : [],
+                        Pipelines = childTypes.HasFlag(AzureDevOpsProjectChildTypes.Pipelines)
+                            ?
+                            [
+                                new AzureDevOpsPipeline 
+                                {
+                                    Id = 1,
+                                    Name = "MyPipeline.One",
+                                    Folder = "\\",
+                                    Revision = 3,
+                                    Links = new(
+                                    new("https://mypipeline.com"),
+                                    new("https://mypipeline.com")
+                                )
+                                }
+                            ]
+                            : []
+                    }
+                ]
+            };
+
+            var result = await service.TestWriteIndex(organization);
+
+            await Verify(result);
+        }
 
     }
 }

--- a/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
@@ -31,23 +31,40 @@ public class OrganizationMarkdownService(ICakeContext cakeContext, TimeProvider 
             await writer.WriteLineAsync($"    %% {project.Name} project");
             await writer.WriteLineAsync($"    subgraph Proj_{project.Id}[{project.Name}]");
             await writer.WriteLineAsync("        direction TB");
-            await writer.WriteLineAsync($"        %% {project.Name} repos");
-            await writer.WriteLineAsync($"        subgraph Repos_{project.Id}[Repositories]");
 
-            foreach (var repo in project.Children)
+            if (project.ChildTypes.HasFlag(AzureDevOpsProjectChildTypes.Repositories))
             {
-                var nodeId = $"Repo_{project.Id}_{repo.Id}";
-                var relativeUrl = $"{project.Name}/Repositories/{repo.Name}/";
-
-                await writer.WriteLineAsync($"            {nodeId}[{repo.Name}]");
-                await writer.WriteLineAsync($"            click {nodeId} href \"{relativeUrl}\" \"{repo.Name}\"");
+                await writer.WriteLineAsync($"        %% {project.Name} repos");
+                await writer.WriteLineAsync($"        subgraph Repos_{project.Id}[Repositories]");
+                foreach (var repo in project.Children)
+                {
+                    var nodeId = $"Repo_{project.Id}_{repo.Id}";
+                    var relativeUrl = $"{project.Name}/Repositories/{repo.Name}/";
+                    await writer.WriteLineAsync($"            {nodeId}[{repo.Name}]");
+                    await writer.WriteLineAsync($"            click {nodeId} href \"{relativeUrl}\" \"{repo.Name}\"");
+                }
+                await writer.WriteLineAsync("        end");
             }
-            await writer.WriteLineAsync("        end");
+
+            if (project.ChildTypes.HasFlag(AzureDevOpsProjectChildTypes.Pipelines))
+            {
+                await writer.WriteLineAsync($"        %% {project.Name} pipelines");
+                await writer.WriteLineAsync($"        subgraph Pipelines_{project.Id}[Pipelines]");
+
+                foreach (var pipeline in project.Pipelines)
+                {
+                    var nodeId = $"Pipeline_{project.Id}_{pipeline.Id}";
+                    var relativeUrl = $"{project.Name}/Build/Pipelines/{pipeline.Name}/";
+                    await writer.WriteLineAsync($"            {nodeId}[{pipeline.Name}]");
+                    await writer.WriteLineAsync($"            click {nodeId} href \"{relativeUrl}\" \"{pipeline.Name}\"");
+                }
+                await writer.WriteLineAsync("        end");
+            }
+
             await writer.WriteLineAsync("    end");
             await writer.WriteLineAsync();
             await writer.WriteLineAsync($"    Org_{organization.Id} --> Proj_{project.Id}");
         }
-
         await writer.WriteLineAsync("```");
     }
 }


### PR DESCRIPTION
# PR: Add Pipeline Mermaid Support for InventoryAllCommand

## Overview
This PR adds support for generating a Mermaid diagram section for pipelines. When using the InventoryAllCommand, the generated diagram now includes both the Repositories and Pipelines subgraphs, providing a more comprehensive view of the organization.

## Key Changes
- Updated `WriteMermaidDiagram` to conditionally output a "Pipelines" subgraph based on the project flags.
- Ensured that if both Repositories and Pipelines are enabled (via `AzureDevOpsProjectChildTypes.All`), both subgraphs are generated.
- Adjusted node URLs and labels for pipelines to integrate seamlessly with the existing Repositories diagram.


Fixes #75 