### PR TITLE
Feature/gh 79

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ AZDOI uses the following environment variables for configuration:
 | `--exclude-repository`         | Exclude specific repositories               |                                                 |
 | `--include-repository-readme`  | Include specific repository README          |                                                 |
 | `--exclude-repository-readme`  | Exclude specific repository README          |                                                 |
-| `--skip-org-graph`              | Skip generating the org graph              |                                                 |
+| `--skip-org-graph`             | Skip generating the org graph               |                                                 |
 
 ### Inventory pipelines
 
@@ -109,7 +109,9 @@ AZDOI uses the following environment variables for configuration:
 | `--exclude-project`            | Exclude specific projects                   |                                                 |
 | `--include-pipeline`           | Include specific pipeline                   |                                                 |
 | `--exclude-pipeline`           | Exclude specific pipeline                   |                                                 |
-| `--skip-org-graph`              | Skip generating the org graph              |                                                 |
+| `--include-release`            | Include specific release                    |                                                 |
+| `--exclude-release`            | Exclude specific release                    |                                                 |
+| `--skip-org-graph`             | Skip generating the org graph               |                                                 |
 
 ### Inventory all
 
@@ -140,11 +142,13 @@ AZDOI uses the following environment variables for configuration:
 | `--exclude-project`            | Exclude specific projects                   |                                                 |
 | `--include-pipeline`           | Include specific pipeline                   |                                                 |
 | `--exclude-pipeline`           | Exclude specific pipeline                   |                                                 |
+| `--include-release`            | Include specific release                    |                                                 |
+| `--exclude-release`            | Exclude specific release                    |                                                 |
 | `--include-repository`         | Include specific repositories               |                                                 |
 | `--exclude-repository`         | Exclude specific repositories               |                                                 |
 | `--include-repository-readme`  | Include specific repository README          |                                                 |
 | `--exclude-repository-readme`  | Exclude specific repository README          |                                                 |
-| `--skip-org-graph`              | Skip generating the org graph              |                                                 |
+| `--skip-org-graph`             | Skip generating the org graph               |                                                 |
 
 
 ## Setting environment variables

--- a/src/AZDOI.Tests/AZDOI.Tests.csproj
+++ b/src/AZDOI.Tests/AZDOI.Tests.csproj
@@ -27,6 +27,9 @@
 		<None Remove="Resources\Routes.json" />
 	</ItemGroup>
 	<ItemGroup>
+	  <EmbeddedResource Include="Resources\Authorized\Releases.json" />
+	</ItemGroup>
+	<ItemGroup>
 		<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/AZDOI.Tests/Resources/Authorized/Releases.json
+++ b/src/AZDOI.Tests/Resources/Authorized/Releases.json
@@ -1,0 +1,51 @@
+﻿{
+    "value": [
+        {
+            "_links": {
+                "self": {
+                    "href": "https://dev.azure.com/test-org/_apis/releases/123?revision=1"
+                },
+                "web": {
+                    "href": "https://dev.azure.com/test-org/_build/definition?definitionId=123"
+                }
+            },
+            "id": "123",
+            "name": "Test Release",
+            "url": "https://dev.azure.com/test-org/_apis/releases/123",
+            "path": "\\",
+            "description": "Release description one",
+            "revision": "3"
+        },
+        {
+            "_links": {
+                "self": {
+                    "href": "https://dev.azure.com/test-org/_apis/releases/123?revision=1"
+                },
+                "web": {
+                    "href": "https://dev.azure.com/test-org/_build/definition?definitionId=222"
+                }
+            },
+            "id": "222",
+            "name": "Test Release",
+            "url": "https://dev.azure.com/test-org/_apis/releases/222",
+            "path": "\\",
+            "revision": "5"
+        },
+        {
+            "_links": {
+                "self": {
+                    "href": "https://dev.azure.com/test-org/_apis/releases/123?revision=1"
+                },
+                "web": {
+                    "href": "https://dev.azure.com/test-org/_build/definition?definitionId=583"
+                }
+            },
+            "id": "583",
+            "name": "Test Release",
+            "url": "https://dev.azure.com/test-org/_apis/releases/583",
+            "description": "Release description two",
+            "path": "\\",
+            "revision": "7"
+        }
+    ]
+}

--- a/src/AZDOI.Tests/Resources/Routes.json
+++ b/src/AZDOI.Tests/Resources/Routes.json
@@ -190,5 +190,29 @@
                 "Basic YWRvOnRlc3QtcGF0"
             ]
         }
+    },
+    {
+        "Request": {
+            "Methods": [
+                {
+                    "Method": "GET"
+                }
+            ],
+            "AbsoluteUri": "https://vsrm.dev.azure.com/test-org/123/_apis/release/definitions?api-version=7.2-preview.4"
+        },
+        "Responses": [
+            {
+                "RequestHeaders": {},
+                "ContentResource": "Authorized.Releases.json",
+                "ContentType": "application/json",
+                "ContentHeaders": {},
+                "StatusCode": 200
+            }
+        ],
+        "Authorization": {
+            "Authorization": [
+                "Basic YWRvOnRlc3QtcGF0"
+            ]
+        }
     }
 ]

--- a/src/AZDOI.Tests/Unit/Clients/AzureDevOpsClientTests.FilterReleases.GetReleases_organization=test-org_project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Clients/AzureDevOpsClientTests.FilterReleases.GetReleases_organization=test-org_project=123.verified.txt
@@ -1,0 +1,46 @@
+﻿[
+  {
+    Name: Test Release,
+    Id: 123,
+    Revision: 3,
+    Path: \,
+    Description: Release description one,
+    Links: {
+      Self: {
+        Href: https://dev.azure.com/test-org/_apis/releases/123?revision=1
+      },
+      Web: {
+        Href: https://dev.azure.com/test-org/_build/definition?definitionId=123
+      }
+    }
+  },
+  {
+    Name: Test Release,
+    Id: 222,
+    Revision: 5,
+    Path: \,
+    Links: {
+      Self: {
+        Href: https://dev.azure.com/test-org/_apis/releases/123?revision=1
+      },
+      Web: {
+        Href: https://dev.azure.com/test-org/_build/definition?definitionId=222
+      }
+    }
+  },
+  {
+    Name: Test Release,
+    Id: 583,
+    Revision: 7,
+    Path: \,
+    Description: Release description two,
+    Links: {
+      Self: {
+        Href: https://dev.azure.com/test-org/_apis/releases/123?revision=1
+      },
+      Web: {
+        Href: https://dev.azure.com/test-org/_build/definition?definitionId=583
+      }
+    }
+  }
+]

--- a/src/AZDOI.Tests/Unit/Clients/AzureDevOpsClientTests.cs
+++ b/src/AZDOI.Tests/Unit/Clients/AzureDevOpsClientTests.cs
@@ -43,6 +43,24 @@ public class AzureDevOpsClientTests
         }
     }
 
+    public class FilterReleases
+    {
+        [Theory]
+        [InlineData("test-org", "123")]
+        public async Task GetReleases(string organization, string project)
+        {
+            // Given
+            var azureDevOpsClient = ServiceProviderFixture
+                                        .GetRequiredService<AzureDevOpsClient>(services => services.AuthorizedClient());
+
+            // When
+            var result = await azureDevOpsClient.GetReleases(organization, project);
+
+            // Then
+            await Verify(result);
+        }
+    }
+
     public class FilterRepositories
     {
         [Theory]

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
@@ -627,7 +627,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2003
+            Length: 1881
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-entraid-org,-output,--entra-id-auth.verified.txt
@@ -73,6 +73,23 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -86,6 +103,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -175,6 +209,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -188,6 +239,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -288,6 +356,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-entraid-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-entraid-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -295,7 +377,7 @@
                     Path: /output/test-entraid-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -319,7 +401,7 @@
                 Path: /output/test-entraid-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 748
+                Length: 782
               }
             ]
           },
@@ -346,6 +428,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-entraid-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-entraid-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -353,7 +449,7 @@
                     Path: /output/test-entraid-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -377,7 +473,7 @@
                 Path: /output/test-entraid-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -404,6 +500,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-entraid-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-entraid-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -411,7 +521,7 @@
                     Path: /output/test-entraid-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -435,7 +545,7 @@
                 Path: /output/test-entraid-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -462,6 +572,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-entraid-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-entraid-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -469,7 +593,7 @@
                     Path: /output/test-entraid-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -493,7 +617,7 @@
                 Path: /output/test-entraid-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -1456,7 +1456,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2937
+            Length: 3294
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -580,6 +580,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -593,6 +817,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -682,6 +923,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -695,6 +953,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -838,6 +1113,35 @@
                         Length: 628
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -845,7 +1149,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 624
+                    Length: 1150
                   }
                 ]
               },
@@ -926,7 +1230,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2022
+                Length: 2548
               }
             ]
           },
@@ -953,6 +1257,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -960,7 +1278,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -984,7 +1302,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1011,6 +1329,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1018,7 +1350,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1042,7 +1374,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1069,6 +1401,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1076,7 +1422,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1100,7 +1446,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
@@ -73,6 +73,23 @@
       ]
     },
     {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project2,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -124,6 +141,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -137,6 +171,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -237,6 +288,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -244,7 +309,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -268,7 +333,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -295,6 +360,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -302,7 +381,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -326,7 +405,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -353,6 +432,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -360,7 +453,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -384,7 +477,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-project=123.verified.txt
@@ -487,7 +487,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1545
+            Length: 1452
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
@@ -102,7 +102,7 @@
       ]
     },
     {
-      Information: Project: Test Project - Repository: Test Repository - README Excluded.,
+      Information: Project: Test Project - Repository: Test Repository - README Exists: True, Length: 101 characters,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
         {
@@ -120,7 +120,13 @@
           RepoName: Test Repository
         },
         {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Excluded.
+          Exists: True
+        },
+        {
+          Length: 101
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
         }
       ]
     },
@@ -667,75 +673,6 @@
           ProjectId: 123
         },
         {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
           Release: 222
         }
       ],
@@ -1216,7 +1153,7 @@
                         Path: /output/test-org/Test Project/Build/Releases/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 465
+                        Length: 394
                       }
                     ]
                   }
@@ -1226,7 +1163,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 1253
+                    Length: 1150
                   }
                 ]
               },
@@ -1245,7 +1182,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 2544
+                        Length: 2625
                       }
                     ]
                   },
@@ -1307,7 +1244,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2651
+                Length: 2548
               }
             ]
           },

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
@@ -1470,7 +1470,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 3300
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository-readme=Test Repository.verified.txt
@@ -1533,7 +1533,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 3438
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
@@ -1450,7 +1450,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2942
+            Length: 3299
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--exclude-repository=456.verified.txt
@@ -574,6 +574,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -587,6 +811,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -676,6 +917,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -689,6 +947,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -846,6 +1121,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -853,7 +1157,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               },
@@ -920,7 +1224,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1990
+                Length: 2516
               }
             ]
           },
@@ -947,6 +1251,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -954,7 +1272,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -978,7 +1296,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1005,6 +1323,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1012,7 +1344,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1036,7 +1368,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1063,6 +1395,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1070,7 +1416,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1094,7 +1440,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -1290,7 +1290,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2640
+            Length: 2997
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -442,6 +442,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -455,6 +679,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -544,6 +785,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -557,6 +815,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -672,6 +947,35 @@
                         Length: 326
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -679,7 +983,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 418
+                    Length: 944
                   }
                 ]
               },
@@ -760,7 +1064,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1816
+                Length: 2342
               }
             ]
           },
@@ -787,6 +1091,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -794,7 +1112,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -818,7 +1136,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -845,6 +1163,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -852,7 +1184,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -876,7 +1208,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -903,6 +1235,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -910,7 +1256,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -934,7 +1280,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -1119,7 +1119,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1911
+            Length: 2361
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -649,6 +649,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -768,6 +992,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -775,7 +1028,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               },
@@ -856,7 +1109,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2125
+                Length: 2651
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
@@ -102,7 +102,7 @@
       ]
     },
     {
-      Information: Project: Test Project - Repository: Test Repository - README Excluded.,
+      Information: Project: Test Project - Repository: Test Repository - README Exists: True, Length: 101 characters,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
         {
@@ -120,7 +120,13 @@
           RepoName: Test Repository
         },
         {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Excluded.
+          Exists: True
+        },
+        {
+          Length: 101
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
         }
       ]
     },
@@ -729,144 +735,6 @@
       ]
     },
     {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -1216,7 +1084,7 @@
                         Path: /output/test-org/Test Project/Build/Releases/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 465
+                        Length: 323
                       }
                     ]
                   }
@@ -1226,7 +1094,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 1253
+                    Length: 1047
                   }
                 ]
               },
@@ -1245,7 +1113,7 @@
                         Path: /output/test-org/Test Project/Repositories/Test Repository/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 2544
+                        Length: 2625
                       }
                     ]
                   },
@@ -1307,7 +1175,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2651
+                Length: 2445
               }
             ]
           },

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
@@ -1401,7 +1401,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 3162
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
@@ -1521,7 +1521,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 3438
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository-readme=Test Repository.verified.txt
@@ -631,6 +631,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -644,6 +868,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -733,6 +974,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -746,6 +1004,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -903,6 +1178,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -910,7 +1214,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               },
@@ -991,7 +1295,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2125
+                Length: 2651
               }
             ]
           },
@@ -1018,6 +1322,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1025,7 +1343,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1049,7 +1367,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1076,6 +1394,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1083,7 +1415,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1107,7 +1439,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1134,6 +1466,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1141,7 +1487,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1165,7 +1511,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
@@ -424,6 +424,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -437,6 +661,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -526,6 +767,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -539,6 +797,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -696,6 +971,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -703,7 +1007,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               },
@@ -742,7 +1046,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1720
+                Length: 2246
               }
             ]
           },
@@ -769,6 +1073,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -776,7 +1094,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -800,7 +1118,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -827,6 +1145,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -834,7 +1166,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -858,7 +1190,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -885,6 +1217,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -892,7 +1238,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -916,7 +1262,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat,--include-repository=456.verified.txt
@@ -1272,7 +1272,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2655
+            Length: 3012
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
@@ -1539,7 +1539,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 3438
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.RunAsync_outputPathExists=True_args=inventory,all,test-org,-output,--pat=test-pat.verified.txt
@@ -649,6 +649,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -662,6 +886,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -751,6 +992,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryAllCommand,
       Scopes: [
@@ -764,6 +1022,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryAllCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -921,6 +1196,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -928,7 +1232,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               },
@@ -1009,7 +1313,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2125
+                Length: 2651
               }
             ]
           },
@@ -1036,6 +1340,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1043,7 +1361,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1067,7 +1385,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1094,6 +1412,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1101,7 +1433,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1125,7 +1457,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           },
@@ -1152,6 +1484,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -1159,7 +1505,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               },
@@ -1183,7 +1529,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 750
+                Length: 784
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.cs
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryAllCommandTests.cs
@@ -13,6 +13,8 @@ public class InventoryAllCommandTests
     [InlineData(true, "inventory", "all", "test-entraid-org", "/output", "--entra-id-auth")]
     [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--include-pipeline=123")]
     [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--exclude-pipeline=123")]
+    [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--include-release=123")]
+    [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--exclude-release=123")]
     [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--include-project=123")]
     [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--exclude-project=123")]
     [InlineData(true, "inventory", "all", "test-org", "/output", "--pat=test-pat", "--include-repository=456")]

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=False_args=inventory,pipelines,--help.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=False_args=inventory,pipelines,--help.verified.txt
@@ -27,6 +27,8 @@ OPTIONS:
         --skip-org-graph      Skip generating the org graph                     
         --include-pipeline    Include specific pipelines                        
         --exclude-pipeline    Exclude specific pipelines                        
+        --include-release     Include specific releases                         
+        --exclude-release     Exclude specific releases                         
 ,
   LogOutput: [],
   FileSystem: {

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,--help.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,--help.verified.txt
@@ -27,6 +27,8 @@ OPTIONS:
         --skip-org-graph      Skip generating the org graph                     
         --include-pipeline    Include specific pipelines                        
         --exclude-pipeline    Exclude specific pipelines                        
+        --include-release     Include specific releases                         
+        --exclude-release     Exclude specific releases                         
 ,
   LogOutput: [],
   FileSystem: {

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
@@ -56,6 +56,23 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -118,6 +135,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-entraid-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-entraid-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -125,7 +156,7 @@
                     Path: /output/test-entraid-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -135,7 +166,7 @@
                 Path: /output/test-entraid-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 706
+                Length: 740
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
@@ -176,7 +176,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 729
+            Length: 717
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -975,7 +975,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2049
+            Length: 2477
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-pipeline=123.verified.txt
@@ -263,6 +263,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -276,6 +500,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -331,6 +572,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -344,6 +602,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -470,6 +745,35 @@
                         Length: 628
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -477,7 +781,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 624
+                    Length: 1150
                   }
                 ]
               }
@@ -487,7 +791,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1197
+                Length: 1723
               }
             ]
           },
@@ -514,6 +818,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -521,7 +839,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -531,7 +849,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -558,6 +876,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -565,7 +897,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -575,7 +907,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -602,6 +934,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -609,7 +955,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -619,7 +965,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
@@ -3,11 +3,11 @@
   ConsoleOutput: ,
   LogOutput: [
     {
-      Information: Executing Inventory Repositories,Pipelines Command...,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Information: Executing Inventory Pipelines Command...,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
-          commandName: Repositories,Pipelines
+          commandName: Pipelines
         },
         {
           {OriginalFormat}: Executing Inventory {commandName} Command...
@@ -16,7 +16,7 @@
     },
     {
       Information: Cleaning directory /output/test-org...,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           TargetPath: /output/test-org
@@ -28,7 +28,7 @@
     },
     {
       Information: Done cleaning directory /output/test-org.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           TargetPath: /output/test-org
@@ -40,318 +40,7 @@
     },
     {
       Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository - README Excluded.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Excluded.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -368,7 +57,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -391,7 +80,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -414,7 +103,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -437,7 +126,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -460,7 +149,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -483,7 +172,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -506,7 +195,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -529,7 +218,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -552,7 +241,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -575,7 +264,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -598,7 +287,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -621,7 +310,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -644,7 +333,7 @@
     },
     {
       Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -661,76 +350,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -753,7 +373,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -776,7 +396,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -799,7 +419,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -822,7 +442,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -845,7 +465,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -868,7 +488,7 @@
     },
     {
       Information: Markdown index created for project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -885,7 +505,7 @@
     },
     {
       Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -902,24 +522,7 @@
     },
     {
       Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 321
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -936,7 +539,7 @@
     },
     {
       Information: Markdown index created for project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -953,7 +556,7 @@
     },
     {
       Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -970,24 +573,7 @@
     },
     {
       Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 999
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -1004,7 +590,7 @@
     },
     {
       Information: Markdown index created for project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -1021,7 +607,7 @@
     },
     {
       Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1038,24 +624,7 @@
     },
     {
       Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 888
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1072,7 +641,7 @@
     },
     {
       Information: Markdown index created for project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1089,7 +658,7 @@
     },
     {
       Information: Processed inventory in 00:00:00.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           Elapsed: 00:00:00
@@ -1216,7 +785,7 @@
                         Path: /output/test-org/Test Project/Build/Releases/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 465
+                        Length: 394
                       }
                     ]
                   }
@@ -1226,78 +795,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 1253
-                  }
-                ]
-              },
-              {
-                Path: /output/test-org/Test Project/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 2544
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository2,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository3,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository4,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  }
-                ],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 926
+                    Length: 1150
                   }
                 ]
               }
@@ -1307,7 +805,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2651
+                Length: 1723
               }
             ]
           },
@@ -1358,20 +856,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project2/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project2/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1379,7 +863,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           },
@@ -1430,20 +914,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project3/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project3/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1451,7 +921,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           },
@@ -1502,20 +972,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project4/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project4/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1523,7 +979,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           }
@@ -1533,7 +989,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 2193
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--exclude-release=123.verified.txt
@@ -989,7 +989,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2193
+            Length: 2483
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -125,6 +125,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -138,6 +362,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -193,6 +434,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -206,6 +464,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -304,6 +579,35 @@
                         Length: 326
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -311,7 +615,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 418
+                    Length: 944
                   }
                 ]
               }
@@ -321,7 +625,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 991
+                Length: 1517
               }
             ]
           },
@@ -348,6 +652,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -355,7 +673,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -365,7 +683,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -392,6 +710,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -399,7 +731,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -409,7 +741,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -436,6 +768,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -443,7 +789,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -453,7 +799,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-pipeline=123.verified.txt
@@ -809,7 +809,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1752
+            Length: 2180
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -332,6 +332,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -451,6 +675,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -458,7 +711,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               }
@@ -468,7 +721,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1300
+                Length: 1826
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -731,7 +731,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1266
+            Length: 1733
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
@@ -3,11 +3,11 @@
   ConsoleOutput: ,
   LogOutput: [
     {
-      Information: Executing Inventory Repositories,Pipelines Command...,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Information: Executing Inventory Pipelines Command...,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
-          commandName: Repositories,Pipelines
+          commandName: Pipelines
         },
         {
           {OriginalFormat}: Executing Inventory {commandName} Command...
@@ -16,7 +16,7 @@
     },
     {
       Information: Cleaning directory /output/test-org...,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           TargetPath: /output/test-org
@@ -28,7 +28,7 @@
     },
     {
       Information: Done cleaning directory /output/test-org.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           TargetPath: /output/test-org
@@ -40,318 +40,7 @@
     },
     {
       Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository - README Excluded.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 456
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Excluded.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository2 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 654
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository2
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository3 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 666
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository3
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Repository: Test Repository4 - README Exists: False, Length: 0 characters,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Repository: 777
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          RepoName: Test Repository4
-        },
-        {
-          Exists: False
-        },
-        {
-          Length: 0
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Repository: {RepoName} - README Exists: {Exists}, Length: {Length} characters
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -368,7 +57,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -391,7 +80,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -414,7 +103,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -437,7 +126,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -460,7 +149,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -483,7 +172,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline2.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -506,7 +195,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -529,7 +218,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -552,7 +241,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline3.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -575,7 +264,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -598,7 +287,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4 - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -621,7 +310,7 @@
     },
     {
       Information: Project: Test Project - Pipeline: Test Pipeline4.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -644,7 +333,7 @@
     },
     {
       Information: Project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -661,7 +350,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -684,7 +373,7 @@
     },
     {
       Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -707,151 +396,13 @@
     },
     {
       Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
         },
         {
           Release: 123
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 222
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release - Markdown index created.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project
-        },
-        {
-          ReleaseName: Test Release
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project - Release: Test Release.,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 123
-        },
-        {
-          Release: 583
         }
       ],
       State: [
@@ -868,7 +419,7 @@
     },
     {
       Information: Markdown index created for project: Test Project,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 123
@@ -885,7 +436,7 @@
     },
     {
       Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -902,24 +453,7 @@
     },
     {
       Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 321
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project2
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -936,7 +470,7 @@
     },
     {
       Information: Markdown index created for project: Test Project2,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 321
@@ -953,7 +487,7 @@
     },
     {
       Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -970,24 +504,7 @@
     },
     {
       Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 999
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project3
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -1004,7 +521,7 @@
     },
     {
       Information: Markdown index created for project: Test Project3,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 999
@@ -1021,7 +538,7 @@
     },
     {
       Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1038,24 +555,7 @@
     },
     {
       Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
-      Scopes: [
-        {
-          ProjectId: 888
-        }
-      ],
-      State: [
-        {
-          ProjectName: Test Project4
-        },
-        {
-          {OriginalFormat}: Project: {ProjectName}
-        }
-      ]
-    },
-    {
-      Information: Project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1072,7 +572,7 @@
     },
     {
       Information: Markdown index created for project: Test Project4,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
         {
           ProjectId: 888
@@ -1089,7 +589,7 @@
     },
     {
       Information: Processed inventory in 00:00:00.,
-      Category: AZDOI.Commands.InventoryAllCommand,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
       State: [
         {
           Elapsed: 00:00:00
@@ -1216,7 +716,7 @@
                         Path: /output/test-org/Test Project/Build/Releases/index.md,
                         Exists: true,
                         Hidden: false,
-                        Length: 465
+                        Length: 323
                       }
                     ]
                   }
@@ -1226,78 +726,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 1253
-                  }
-                ]
-              },
-              {
-                Path: /output/test-org/Test Project/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 2544
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository2,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository2/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository3,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository3/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  },
-                  {
-                    Path: /output/test-org/Test Project/Repositories/Test Repository4,
-                    Exists: true,
-                    Hidden: false,
-                    Directories: [],
-                    Files: [
-                      {
-                        Path: /output/test-org/Test Project/Repositories/Test Repository4/index.md,
-                        Exists: true,
-                        Hidden: false,
-                        Length: 1596
-                      }
-                    ]
-                  }
-                ],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 926
+                    Length: 1047
                   }
                 ]
               }
@@ -1307,7 +736,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 2651
+                Length: 1620
               }
             ]
           },
@@ -1358,20 +787,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project2/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project2/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1379,7 +794,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           },
@@ -1430,20 +845,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project3/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project3/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1451,7 +852,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           },
@@ -1502,20 +903,6 @@
                     Length: 167
                   }
                 ]
-              },
-              {
-                Path: /output/test-org/Test Project4/Repositories,
-                Exists: true,
-                Hidden: false,
-                Directories: [],
-                Files: [
-                  {
-                    Path: /output/test-org/Test Project4/Repositories/index.md,
-                    Exists: true,
-                    Hidden: false,
-                    Length: 143
-                  }
-                ]
               }
             ],
             Files: [
@@ -1523,7 +910,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 784
+                Length: 742
               }
             ]
           }
@@ -1533,7 +920,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 3081
+            Length: 2193
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat,--include-release=123.verified.txt
@@ -920,7 +920,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2193
+            Length: 2345
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
@@ -1058,7 +1058,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2193
+            Length: 2621
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output,--pat=test-pat.verified.txt
@@ -332,6 +332,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -345,6 +569,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -400,6 +641,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -413,6 +671,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -553,6 +828,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -560,7 +864,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               }
@@ -570,7 +874,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1300
+                Length: 1826
               }
             ]
           },
@@ -597,6 +901,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -604,7 +922,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -614,7 +932,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -641,6 +959,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -648,7 +980,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -658,7 +990,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -685,6 +1017,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -692,7 +1038,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -702,7 +1048,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
@@ -1058,7 +1058,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2193
+            Length: 2621
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.RunAsync_outputPathExists=True_args=inventory,pipelines,test-org,-output.verified.txt
@@ -332,6 +332,230 @@
       ]
     },
     {
+      Information: Project: Test Project,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 123
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 222
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release - Markdown index created.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project - Release: Test Release.,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 123
+        },
+        {
+          Release: 583
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project
+        },
+        {
+          ReleaseName: Test Release
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName} - Release: {ReleaseName}.
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -345,6 +569,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project2,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 321
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project2
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -400,6 +641,23 @@
       ]
     },
     {
+      Information: Project: Test Project3,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 999
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project3
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
+        }
+      ]
+    },
+    {
       Information: Markdown index created for project: Test Project3,
       Category: AZDOI.Commands.InventoryPipelinesCommand,
       Scopes: [
@@ -413,6 +671,23 @@
         },
         {
           {OriginalFormat}: Markdown index created for project: {ProjectName}
+        }
+      ]
+    },
+    {
+      Information: Project: Test Project4,
+      Category: AZDOI.Commands.InventoryPipelinesCommand,
+      Scopes: [
+        {
+          ProjectId: 888
+        }
+      ],
+      State: [
+        {
+          ProjectName: Test Project4
+        },
+        {
+          {OriginalFormat}: Project: {ProjectName}
         }
       ]
     },
@@ -553,6 +828,35 @@
                         Length: 731
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/Test Release,
+                        Exists: true,
+                        Hidden: false,
+                        Directories: [],
+                        Files: [
+                          {
+                            Path: /output/test-org/Test Project/Build/Releases/Test Release/index.md,
+                            Exists: true,
+                            Hidden: false,
+                            Length: 1301
+                          }
+                        ]
+                      }
+                    ],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 465
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -560,7 +864,7 @@
                     Path: /output/test-org/Test Project/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 727
+                    Length: 1253
                   }
                 ]
               }
@@ -570,7 +874,7 @@
                 Path: /output/test-org/Test Project/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 1300
+                Length: 1826
               }
             ]
           },
@@ -597,6 +901,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project2/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project2/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -604,7 +922,7 @@
                     Path: /output/test-org/Test Project2/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -614,7 +932,7 @@
                 Path: /output/test-org/Test Project2/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -641,6 +959,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project3/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project3/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -648,7 +980,7 @@
                     Path: /output/test-org/Test Project3/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -658,7 +990,7 @@
                 Path: /output/test-org/Test Project3/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           },
@@ -685,6 +1017,20 @@
                         Length: 137
                       }
                     ]
+                  },
+                  {
+                    Path: /output/test-org/Test Project4/Build/Releases,
+                    Exists: true,
+                    Hidden: false,
+                    Directories: [],
+                    Files: [
+                      {
+                        Path: /output/test-org/Test Project4/Build/Releases/index.md,
+                        Exists: true,
+                        Hidden: false,
+                        Length: 133
+                      }
+                    ]
                   }
                 ],
                 Files: [
@@ -692,7 +1038,7 @@
                     Path: /output/test-org/Test Project4/Build/index.md,
                     Exists: true,
                     Hidden: false,
-                    Length: 133
+                    Length: 167
                   }
                 ]
               }
@@ -702,7 +1048,7 @@
                 Path: /output/test-org/Test Project4/index.md,
                 Exists: true,
                 Hidden: false,
-                Length: 708
+                Length: 742
               }
             ]
           }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.cs
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryPipelinesCommandTests.cs
@@ -26,6 +26,8 @@ public class InventoryPipelinesCommandTests
     [InlineData(true, "inventory", "pipelines", "test-org", "/output", "--pat=test-pat", "--exclude-pipeline=123")]
     [InlineData(true, "inventory", "pipelines", "test-org", "/output", "--pat=test-pat", "--include-project=123")]
     [InlineData(true, "inventory", "pipelines", "test-entraid-org", "/output", "--entra-id-auth", "--include-project=123")]
+    [InlineData(true, "inventory", "pipelines", "test-org", "/output", "--pat=test-pat", "--include-release=123")]
+    [InlineData(true, "inventory", "pipelines", "test-org", "/output", "--pat=test-pat", "--exclude-release=123")]
     public async Task RunAsync(bool outputPathExists, params string[] args)
     {
         // Given

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
@@ -130,7 +130,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 724
+            Length: 712
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123,--include-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123,--include-repository-readme=Test Repository.verified.txt
@@ -130,7 +130,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 724
+            Length: 712
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-entraid-org,-output,--entra-id-auth,--include-project=123.verified.txt
@@ -130,7 +130,7 @@
             Path: /output/test-entraid-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 724
+            Length: 712
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--exclude-repository-readme=Test Repository.verified.txt
@@ -481,7 +481,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1241
+            Length: 1229
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--include-repository-readme=Test Repository.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123,--include-repository-readme=Test Repository.verified.txt
@@ -469,7 +469,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1241
+            Length: 1229
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat,--include-project=123.verified.txt
@@ -487,7 +487,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 1241
+            Length: 1229
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output,--pat=test-pat.verified.txt
@@ -676,7 +676,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 2102
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/InventoryRepositoriesCommandTests.RunAsync_outputPathExists=True_args=inventory,repositories,test-org,-output.verified.txt
@@ -676,7 +676,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 2102
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Commands/ValidateOrgAttributeTest.RunAsync_args=inventory,repositories,test-org,-output.verified.txt
+++ b/src/AZDOI.Tests/Unit/Commands/ValidateOrgAttributeTest.RunAsync_args=inventory,repositories,test-org,-output.verified.txt
@@ -676,7 +676,7 @@
             Path: /output/test-org/index.md,
             Exists: true,
             Hidden: false,
-            Length: 2153
+            Length: 2102
           }
         ]
       }

--- a/src/AZDOI.Tests/Unit/Markdown/BuildsMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/BuildsMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
@@ -13,3 +13,10 @@ modified: 2000-01-01 00:00
 | [MyPipeline.One](<Pipelines/MyPipeline.One>)                     | MyPipeline.One                   |
 | [MyPipeline.Two](<Pipelines/MyPipeline.Two>)                     | MyPipeline.Two                   |
 
+## Releases
+
+| Release                                                          | Description                      |
+|------------------------------------------------------------------|----------------------------------|
+| [MyRelease.One](<Releases/MyRelease.One>)                        | MyRelease.One                    |
+| [MyRelease.Two](<Releases/MyRelease.Two>)                        | This is a Release descriptions   |
+

--- a/src/AZDOI.Tests/Unit/Markdown/BuildsMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/BuildsMarkdownServiceTests.cs
@@ -3,48 +3,74 @@
 public class BuildsMarkdownServiceTests
 {
     [Fact]
-        public async Task WriteIndex_ShouldWriteExpectedMarkdownContent()
+    public async Task WriteIndex_ShouldWriteExpectedMarkdownContent()
+    {
+        //Given 
+        var (fileSystem, service) = ServiceProviderFixture
+            .GetRequiredService<FakeFileSystem, BuildsMarkdownService>();
+
+        var project = new AzureDevOpsProject
         {
-            //Given 
-            var (fileSystem, service) = ServiceProviderFixture
-                .GetRequiredService<FakeFileSystem, BuildsMarkdownService>();
+            Name = "Project",
+            Id = "1",
+            Url = "https://myproject.com",
+            Pipelines =
+            [
+                new AzureDevOpsPipeline
+                {
+                    Id = 1,
+                    Name = "MyPipeline.One",
+                    Folder = "\\",
+                    Revision = 3,
+                    Links = new (
+                        new ("https://myproject.com"),
+                        new ("https://myproject.com")
+                    )
+                },
+                new AzureDevOpsPipeline
+                {
+                    Id = 2,
+                    Name = "MyPipeline.Two",
+                    Folder = "\\",
+                    Revision = 6,
+                    Links = new (
+                        new ("https://myproject.com"),
+                        new ("https://myproject.com")
+                    )
+                }
+            ],
+            Releases =
+            [
+                new AzureDevOpsRelease
+                {
+                    Id = 1,
+                    Name = "MyRelease.One",
+                    Path = "\\",
+                    Revision = 5,
+                    Links = new (
+                        new ("https://myproject.com"),
+                        new ("https://myproject.com")
+                    )
+                },
+                new AzureDevOpsRelease
+                {
+                    Id = 2,
+                    Name = "MyRelease.Two",
+                    Path = "\\",
+                    Revision = 10,
+                    Description = "This is a Release descriptions",
+                    Links = new (
+                        new ("https://myproject.com"),
+                        new ("https://myproject.com")
+                    )
+                }
+            ]
+        };
 
-            var project = new AzureDevOpsProject
-            {
-                Name = "Project",
-                Id = "1",
-                Url = "https://myproject.com",
-                Pipelines =
-                [
-                    new AzureDevOpsPipeline 
-                    {
-                        Id = 1, 
-                        Name = "MyPipeline.One",
-                        Folder = "\\",
-                        Revision = 3,
-                        Links = new (
-                            new ("https://myproject.com"),
-                            new ("https://myproject.com")
-                            )
-                    },
-                    new AzureDevOpsPipeline 
-                    { 
-                        Id = 2, 
-                        Name = "MyPipeline.Two",
-                        Folder = "\\",
-                        Revision = 6,
-                        Links = new (
-                            new ("https://myproject.com"),
-                            new ("https://myproject.com")
-                            )
-                    }
-                ]
-            };
+        //When
+        var result = await service.TestWriteIndex(project);
 
-            //When
-            var result = await service.TestWriteIndex(project);
-
-            //Then
-            await Verify(result);
-        }
+        //Then
+        await Verify(result);
+    }
 }

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
@@ -19,12 +19,11 @@ graph TD
     %% Test Project project
     subgraph Proj_Proj1[Test Project]
         direction TB
-        %% Test Project repos
+        Repos_Proj1~~~Pipelines_Proj1
         subgraph Repos_Proj1[Repositories]
             Repo_Proj1_1[MyRepository]
             click Repo_Proj1_1 href "Test Project/Repositories/MyRepository/" "MyRepository"
         end
-        %% Test Project pipelines
         subgraph Pipelines_Proj1[Pipelines]
             Pipeline_Proj1_1[MyPipeline.One]
             click Pipeline_Proj1_1 href "Test Project/Build/Pipelines/MyPipeline.One/" "MyPipeline.One"

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
@@ -19,7 +19,7 @@ graph TD
     %% Test Project project
     subgraph Proj_Proj1[Test Project]
         direction TB
-        %% Test Project pipelines
+        Pipelines_Proj1
         subgraph Pipelines_Proj1[Pipelines]
             Pipeline_Proj1_1[MyPipeline.One]
             click Pipeline_Proj1_1 href "Test Project/Build/Pipelines/MyPipeline.One/" "MyPipeline.One"

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Repositories.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.OrgMarkdownChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Repositories.verified.txt
@@ -19,7 +19,7 @@ graph TD
     %% Test Project project
     subgraph Proj_Proj1[Test Project]
         direction TB
-        %% Test Project repos
+        Repos_Proj1
         subgraph Repos_Proj1[Repositories]
             Repo_Proj1_1[MyRepository]
             click Repo_Proj1_1 href "Test Project/Repositories/MyRepository/" "MyRepository"

--- a/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/OrganizationMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
@@ -19,7 +19,7 @@ graph TD
     %% MyProject project
     subgraph Proj_1[MyProject]
         direction TB
-        %% MyProject repos
+        Repos_1
         subgraph Repos_1[Repositories]
         end
     end

--- a/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
@@ -29,3 +29,9 @@ modified: 2000-01-01 00:00
 |------------------------------------------------------------------|----------------------------------|
 | [MyPipeline](<Build/Pipelines/MyPipeline>)                       | MyPipeline                       |
 
+## Releases
+
+| Release                                                          | Description                      |
+|------------------------------------------------------------------|----------------------------------|
+| [MyRelease.One](<Build/Pipelines/MyRelease.One>)                 | Release Description              |
+

--- a/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=All.verified.txt
@@ -33,5 +33,5 @@ modified: 2000-01-01 00:00
 
 | Release                                                          | Description                      |
 |------------------------------------------------------------------|----------------------------------|
-| [MyRelease.One](<Build/Pipelines/MyRelease.One>)                 | Release Description              |
+| [MyRelease.One](<Build/Releases/MyRelease.One>)                  | Release Description              |
 

--- a/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
@@ -27,5 +27,5 @@ modified: 2000-01-01 00:00
 
 | Release                                                          | Description                      |
 |------------------------------------------------------------------|----------------------------------|
-| [MyRelease.One](<Build/Pipelines/MyRelease.One>)                 | Release Description              |
+| [MyRelease.One](<Build/Releases/MyRelease.One>)                  | Release Description              |
 

--- a/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.ChildTypes.WriteIndex_ShouldWriteExpectedMarkdownContent_childTypes=Pipelines.verified.txt
@@ -23,3 +23,9 @@ modified: 2000-01-01 00:00
 |------------------------------------------------------------------|----------------------------------|
 | [MyPipeline](<Build/Pipelines/MyPipeline>)                       | MyPipeline                       |
 
+## Releases
+
+| Release                                                          | Description                      |
+|------------------------------------------------------------------|----------------------------------|
+| [MyRelease.One](<Build/Pipelines/MyRelease.One>)                 | Release Description              |
+

--- a/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/ProjectMarkdownServiceTests.cs
@@ -8,31 +8,44 @@ public class ProjectMarkdownServiceTests
         Name = "DevOps Project",
         Description = "DevOps Project Description",
         Url = "https://myproject.com",
-        Children =
-            [
-                new AzureDevOpsRepository
-                {
-                    Id = "1",
-                    Name = "MyRepository",
-                    Description = "MyRepository Description",
-                    Size = 100,
-                    RemoteUrl = "https://myproject.com",
-                    WebUrl = "https://myproject.com",
-                    Url = "https://myproject.com"
-                }
-            ],
+        Children =[
+            new AzureDevOpsRepository
+            {
+                Id = "1",
+                Name = "MyRepository",
+                Description = "MyRepository Description",
+                Size = 100,
+                RemoteUrl = "https://myproject.com",
+                WebUrl = "https://myproject.com",
+                Url = "https://myproject.com"
+            }
+        ],
         Pipelines = [
-                    new AzureDevOpsPipeline {
-                        Id = 1,
-                        Name = "MyPipeline",
-                        Folder = "\\",
-                        Revision = 3,
-                        Links = new(
-                                    new("https://myproject.com/build/MyPipeline"),
-                                    new("https://myproject.com/build/MyPipeline")
-                                    )
-                    }
-                ]
+            new AzureDevOpsPipeline {
+                Id = 1,
+                Name = "MyPipeline",
+                Folder = "\\",
+                Revision = 3,
+                Links = new(
+                    new("https://myproject.com/build/MyPipeline"),
+                    new("https://myproject.com/build/MyPipeline")
+                )
+            }
+        ],
+        Releases = [
+            new AzureDevOpsRelease
+            {
+                Id = 1,
+                Name = "MyRelease.One",
+                Path = "\\",
+                Revision = 5,
+                Description = "Release Description",
+                Links = new (
+                    new ("https://myproject.com"),
+                    new ("https://myproject.com")
+                )
+            },
+        ]
     };
 
     [Fact]

--- a/src/AZDOI.Tests/Unit/Markdown/ReleaseMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ReleaseMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
@@ -1,0 +1,18 @@
+﻿---
+title: DevOps Release
+summary: Release Description
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# DevOps Release
+
+## Release Details
+
+|                                  |                                                                  |
+|----------------------------------|------------------------------------------------------------------|
+| Id                               | 1                                                                |
+| Name                             | DevOps Release                                                   |
+| WebUrl                           | [myrelease.com](https://myrelease.com)                           |
+| Path                             | \                                                                |
+| Revision                         | 3                                                                |
+

--- a/src/AZDOI.Tests/Unit/Markdown/ReleaseMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/ReleaseMarkdownServiceTests.cs
@@ -1,0 +1,32 @@
+﻿namespace AZDOI.Tests.Unit.Markdown;
+
+public class ReleaseMarkdownServiceTests
+{
+    [Fact]
+    public async Task WriteIndex_ShouldWriteExpectedMarkdownContent()
+    {
+        // Given
+        var (fileSystem, service) = ServiceProviderFixture
+            .GetRequiredService<FakeFileSystem, ReleaseMarkdownService>();
+
+        var release =
+        new AzureDevOpsRelease
+        {
+            Id = 1,
+            Name = "DevOps Release",
+            Path = "\\",
+            Revision = 3,
+            Description = "Release Description",
+            Links = new(
+                new("https://myrelease.com"),
+                new("https://myrelease.com")
+            )
+        };
+
+        // When
+        var result = await service.TestWriteIndex(release);
+
+        // Then
+        await Verify(result);
+    }
+}

--- a/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
+++ b/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.WriteIndex_ShouldWriteExpectedMarkdownContent.verified.txt
@@ -1,0 +1,14 @@
+﻿---
+title: Releases
+summary: Azure DevOps Build Releases
+modifiedby: AZDOI
+modified: 2000-01-01 00:00
+---
+# Releases
+
+| Release                                                          | Description                      |
+|------------------------------------------------------------------|----------------------------------|
+| [MyRelease.One](<MyRelease.One>)                                 | This is a Release description    |
+| [MyRelease.Two](<MyRelease.Two>)                                 | MyRelease.Two                    |
+| [MyRelease.Five](<MyRelease.Five>)                               | This is a Release description    |
+

--- a/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.cs
@@ -1,0 +1,55 @@
+﻿namespace AZDOI.Tests.Unit.Markdown;
+public class ReleasesMarkdownServiceTests
+{
+    [Fact]
+    public async Task WriteIndex_ShouldWriteExpectedMarkdownContent()
+    {
+        //Given 
+        var (fileSystem, services) = ServiceProviderFixture
+            .GetRequiredService<FakeFileSystem, ReleasesMarkdownService>();
+
+        AzureDevOpsRelease[] release = [
+            new AzureDevOpsRelease
+            {
+                Id = 1,
+                Name = "MyRelease.One",
+                Path = "\\",
+                Revision = 2,
+                Description = "This is a Release description",
+                Links = new (
+                    new ("https://myproject.com"),
+                    new ("https://myproject.com")
+                )
+            },
+            new AzureDevOpsRelease
+            {
+                Id = 2,
+                Name = "MyRelease.Two",
+                Path = "\\",
+                Revision = 1,
+                Links = new(
+                    new("https://myproject.com"),
+                    new("https://myproject.com")
+                )
+            },
+            new AzureDevOpsRelease
+            {
+                Id = 5,
+                Name = "MyRelease.Five",
+                Path = "\\",
+                Revision = 15,
+                Description = "This is a Release description",
+                Links = new(
+                    new("https://myproject.com"),
+                    new("https://myproject.com")
+                )
+            }
+        ];
+
+        //When
+        var result = await services.TestWriteIndex(release);
+
+        //Then
+        await Verify(result);
+    }
+}

--- a/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.cs
+++ b/src/AZDOI.Tests/Unit/Markdown/ReleasesMarkdownServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿namespace AZDOI.Tests.Unit.Markdown;
+
 public class ReleasesMarkdownServiceTests
 {
     [Fact]

--- a/src/AZDOI/Commands/InventoryCommand.Projects.cs
+++ b/src/AZDOI/Commands/InventoryCommand.Projects.cs
@@ -44,7 +44,14 @@ public partial class InventoryCommand<TSettings>
                                                     OutputDirectory = buildDirectory,
                                                 },
                                                 sourceProject
-                                    )
+                                    ),
+                                    Releases = await ProcessReleases(
+                                               context with
+                                               {
+                                                   OutputDirectory = buildDirectory,
+                                               },
+                                               sourceProject
+                                        )
                                 };
 
                                 await services.ProjectMarkdownService.WriteIndex(projectOutputDirectory, project);

--- a/src/AZDOI/Commands/InventoryCommand.Releases.cs
+++ b/src/AZDOI/Commands/InventoryCommand.Releases.cs
@@ -1,0 +1,60 @@
+﻿
+namespace AZDOI.Commands;
+public partial class InventoryCommand<TSettings>
+{
+    private async Task<AzureDevOpsRelease[]> ProcessReleases(InventoryContext context, AzureDevOpsProject project)
+    {
+        if (!context.Settings.ProjectChildTypes.HasFlag(AzureDevOpsProjectChildTypes.Pipelines))
+        {
+            return [];
+        }
+
+        Logger.LogInformation("Project: {ProjectName}", project.Name);
+
+        var releasesDirectory = context.OutputDirectory.Combine("Releases");
+
+        var releases =
+            await context.InvokeDevOpsClient(
+                async (client, settings) =>
+                    await context.ForEachAsync(
+                        await client.GetReleases(settings.DevOpsOrg, project.Id, settings.IncludeReleases, settings.ExcludeReleases),
+                        (release, ct) => ProcessRelease(
+                                            context with
+                                            {
+                                                OutputDirectory = releasesDirectory,
+                                            },
+                                            project,
+                                            release
+                        )
+                    )
+                    .OrderBy(_ => _.Name, StringComparer.OrdinalIgnoreCase)
+                    .ToArrayAsync()
+            );
+        await services.ReleasesMarkdownService.WriteIndex(releasesDirectory, releases);
+
+        return releases;
+    }
+
+    private async Task<AzureDevOpsRelease> ProcessRelease(InventoryContext context, AzureDevOpsProject project, AzureDevOpsRelease sourceRelease)
+    {
+        using (Logger.BeginScope(new { Release = sourceRelease.Id }))
+        {
+            Logger.LogInformation("Project: {ProjectName} - Release: {ReleaseName}", project.Name, sourceRelease.Name);
+
+            await services.ReleaseMarkdownService.WriteIndex(
+                context.OutputDirectory.Combine(sourceRelease.Name),
+                sourceRelease
+            );
+
+            Logger.LogInformation("Project: {ProjectName} - Release: {ReleaseName} - Markdown index created.", project.Name, sourceRelease.Name);
+
+            Logger.LogInformation(
+                "Project: {ProjectName} - Release: {ReleaseName}.",
+                project.Name,
+                sourceRelease.Name
+            );
+        }
+        return sourceRelease;
+    }
+}
+

--- a/src/AZDOI/Commands/InventoryCommand.Releases.cs
+++ b/src/AZDOI/Commands/InventoryCommand.Releases.cs
@@ -1,5 +1,5 @@
-﻿
-namespace AZDOI.Commands;
+﻿namespace AZDOI.Commands;
+
 public partial class InventoryCommand<TSettings>
 {
     private async Task<AzureDevOpsRelease[]> ProcessReleases(InventoryContext context, AzureDevOpsProject project)
@@ -57,4 +57,3 @@ public partial class InventoryCommand<TSettings>
         return sourceRelease;
     }
 }
-

--- a/src/AZDOI/Commands/Settings/AZDOIAllSettings.cs
+++ b/src/AZDOI/Commands/Settings/AZDOIAllSettings.cs
@@ -31,4 +31,12 @@ public class AZDOIAllSettings(ICakeEnvironment environment)
     [Description("Exclude specific pipelines")]
     [CommandOption("--exclude-pipeline")]
     public override string[]? ExcludePipelines { get; set; }
+
+    [Description("Include specific releases")]
+    [CommandOption("--include-release")]
+    public override string[]? IncludeReleases { get; set; }
+
+    [Description("Exclude specific releases")]
+    [CommandOption("--exclude-release")]
+    public override string[]? ExcludeReleases { get; set; }
 }

--- a/src/AZDOI/Commands/Settings/AZDOIPipelinesSettings.cs
+++ b/src/AZDOI/Commands/Settings/AZDOIPipelinesSettings.cs
@@ -12,4 +12,12 @@ public class AZDOIPipelinesSettings(ICakeEnvironment environment)
     [Description("Exclude specific pipelines")]
     [CommandOption("--exclude-pipeline")]
     public override string[]? ExcludePipelines { get; set; }
+
+    [Description("Include specific releases")]
+    [CommandOption("--include-release")]
+    public override string[]? IncludeReleases { get; set; }
+
+    [Description("Exclude specific releases")]
+    [CommandOption("--exclude-release")]
+    public override string[]? ExcludeReleases { get; set; }
 }

--- a/src/AZDOI/Commands/Settings/AZDOISettings.cs
+++ b/src/AZDOI/Commands/Settings/AZDOISettings.cs
@@ -59,4 +59,8 @@ public abstract class AZDOISettings(
     public virtual string[]? IncludePipelines { get; set; }
 
     public virtual string[]? ExcludePipelines { get; set; }
+
+    public virtual string[]? IncludeReleases { get; set; }
+
+    public virtual string[]? ExcludeReleases { get; set; }
 }

--- a/src/AZDOI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AZDOI/Extensions/ServiceCollectionExtensions.cs
@@ -102,7 +102,9 @@ public static class ServiceCollectionExtensions
             .AddSingleton<RepositoryMarkdownService>()
             .AddSingleton<PipelineMarkdownService>()
             .AddSingleton<PipelinesMarkdownService>()
-            .AddSingleton<BuildsMarkdownService>();
+            .AddSingleton<BuildsMarkdownService>()
+            .AddSingleton<ReleasesMarkdownService>()
+            .AddSingleton<ReleaseMarkdownService>();
 
         return services;
     }

--- a/src/AZDOI/Models/AzureDevOpsProject.cs
+++ b/src/AZDOI/Models/AzureDevOpsProject.cs
@@ -5,4 +5,6 @@ public record AzureDevOpsProject : AzureDevOpsBase<AzureDevOpsRepository>
     internal AzureDevOpsProjectChildTypes ChildTypes { get; init; } = AzureDevOpsProjectChildTypes.Repositories;
 
     internal AzureDevOpsPipeline[] Pipelines { get; init; } = [];
+    
+    internal AzureDevOpsRelease[] Releases { get; init; } = [];
 }

--- a/src/AZDOI/Models/AzureDevOpsRelease.cs
+++ b/src/AZDOI/Models/AzureDevOpsRelease.cs
@@ -1,0 +1,23 @@
+﻿namespace AZDOI.Models;
+
+public record AzureDevOpsRelease : IAzureDevOpsBase
+{
+    public required string Name { get; init; }
+
+    public required int Id { get; init; }
+
+    internal string WebUrl => Links.Web.Href;
+
+    public required int Revision {  get; init; }
+
+    public required string Path { get; init; }
+
+    public string? Description { get; init; }
+
+    [JsonPropertyName("_links")]
+    public required AzureDevOpsLinks Links { get; init; }
+
+    string IAzureDevOpsBase.Description => Description ?? Name;
+    string IAzureDevOpsBase.Id => FormattableString.Invariant($"{Id}");
+    string IAzureDevOpsBase.Url => WebUrl;
+}

--- a/src/AZDOI/Services/AzureDevOps/AZureDevOpsClient.Releases.cs
+++ b/src/AZDOI/Services/AzureDevOps/AZureDevOpsClient.Releases.cs
@@ -1,0 +1,22 @@
+﻿namespace AZDOI.Services.AzureDevOps;
+
+public partial class AzureDevOpsClient
+{
+    public async Task<AzureDevOpsRelease[]> GetReleases(
+       string organization, 
+       string projectId,
+       IEnumerable<string>? includeNames = null,
+       IEnumerable<string>? excludeNames = null)
+    {
+        var url = $"https://vsrm.dev.azure.com/{Uri.EscapeDataString(organization)}/{Uri.EscapeDataString(projectId)}/_apis/release/definitions?api-version=7.2-preview.4";
+
+        var result = await GetFromJson<AzureDevOpsResponse<AzureDevOpsRelease>>(url);
+
+        var releases = result?.Value ?? [];
+
+        return releases.FilterEnumerable(
+            includeNames,
+            excludeNames,
+            p => p.Id.ToString());
+    }
+}

--- a/src/AZDOI/Services/InventoryCommandServices.cs
+++ b/src/AZDOI/Services/InventoryCommandServices.cs
@@ -11,5 +11,7 @@ public record InventoryCommandServices(
     PipelineMarkdownService PipelineMarkdownService,
     PipelinesMarkdownService PipelinesMarkdownService,
     BuildsMarkdownService BuildsMarkdownService,
-    StopwatchProvider StopwatchProvider
+    StopwatchProvider StopwatchProvider,
+    ReleaseMarkdownService ReleaseMarkdownService,
+    ReleasesMarkdownService ReleasesMarkdownService
     );

--- a/src/AZDOI/Services/Markdown/BuildsMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/BuildsMarkdownService.cs
@@ -22,5 +22,13 @@ public class BuildsMarkdownService(ICakeContext cakeContext, TimeProvider timePr
             "Pipelines",
             urlSelector: pipeline => $"Pipelines/{pipeline.Name}"
             );
+
+        await WriteChildren(
+            writer,
+            project.Releases,
+            "Release",
+            "Releases",
+            urlSelector: release => $"Releases/{release.Name}"
+            );
     }
 }

--- a/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/OrganizationMarkdownService.cs
@@ -79,7 +79,7 @@ public class OrganizationMarkdownService(ICakeContext cakeContext, TimeProvider 
                     foreach (var release in project.Releases)
                     {
                         var nodeId = $"Release_{project.Id}_{release.Id}";
-                        var relativeUrl = $"{release.Name}/Build/Releases/{release.Name}/";
+                        var relativeUrl = $"{project.Name}/Build/Releases/{release.Name}/";
                         await writer.WriteLineAsync($"            {nodeId}[{release.Name}]");
                         await writer.WriteLineAsync($"            click {nodeId} href \"{relativeUrl}\" \"{release.Name}\"");
                     }

--- a/src/AZDOI/Services/Markdown/ProjectMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ProjectMarkdownService.cs
@@ -50,7 +50,15 @@ public class ProjectMarkdownService(ICakeContext cakeContext, TimeProvider timeP
                 "Pipeline",
                 "Pipelines",
                 urlSelector: pipeline => $"Build/Pipelines/{pipeline.Name}"
-                );
+            );
+
+            await WriteChildren(
+                writer,
+                project.Releases,
+                "Release",
+                "Releases",
+                urlSelector: release => $"Build/Pipelines/{release.Name}"
+            );
         }
     }
 }

--- a/src/AZDOI/Services/Markdown/ProjectMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ProjectMarkdownService.cs
@@ -57,7 +57,7 @@ public class ProjectMarkdownService(ICakeContext cakeContext, TimeProvider timeP
                 project.Releases,
                 "Release",
                 "Releases",
-                urlSelector: release => $"Build/Pipelines/{release.Name}"
+                urlSelector: release => $"Build/Releases/{release.Name}"
             );
         }
     }

--- a/src/AZDOI/Services/Markdown/ReleaseMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ReleaseMarkdownService.cs
@@ -1,0 +1,27 @@
+﻿namespace AZDOI.Services.Markdown;
+public class ReleaseMarkdownService(ICakeContext cakeContext, TimeProvider timeProvider)
+    : MarkdownServiceBase<AzureDevOpsRelease>(cakeContext, timeProvider)
+{
+    protected override async Task WriteIndex(FileTextWriter writer, AzureDevOpsRelease release)
+    {
+        await writer.WriteLineAsync(
+            $$"""
+            # {{release.Name}}
+            
+            ## Release Details
+
+            """
+        );
+
+        await WriteTable(
+            writer,
+            [
+                GetKeyValue(release.Id),
+                GetKeyValue(release.Name),
+                GetKeyValue(release.WebUrl),
+                GetKeyValue(release.Path),
+                GetKeyValue(release.Revision),
+            ]
+        );
+    }
+}

--- a/src/AZDOI/Services/Markdown/ReleaseMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ReleaseMarkdownService.cs
@@ -1,4 +1,5 @@
 ﻿namespace AZDOI.Services.Markdown;
+
 public class ReleaseMarkdownService(ICakeContext cakeContext, TimeProvider timeProvider)
     : MarkdownServiceBase<AzureDevOpsRelease>(cakeContext, timeProvider)
 {

--- a/src/AZDOI/Services/Markdown/ReleasesMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ReleasesMarkdownService.cs
@@ -1,0 +1,18 @@
+﻿namespace AZDOI.Services.Markdown;
+public class ReleasesMarkdownService(ICakeContext cakeContext, TimeProvider timeProvider)
+    : MarkdownServiceBase<AzureDevOpsRelease[]>(cakeContext, timeProvider)
+{
+    protected override string? Title => "Releases";
+    protected override string? Summary => "Azure DevOps Build Releases";
+
+    protected override async Task WriteIndex(FileTextWriter writer, AzureDevOpsRelease[] children)
+    {
+        await WriteChildren(
+           writer,
+           children,
+           "Release",
+           "Releases",
+           headingLevel: 1
+        );
+    }
+}

--- a/src/AZDOI/Services/Markdown/ReleasesMarkdownService.cs
+++ b/src/AZDOI/Services/Markdown/ReleasesMarkdownService.cs
@@ -1,4 +1,5 @@
 ﻿namespace AZDOI.Services.Markdown;
+
 public class ReleasesMarkdownService(ICakeContext cakeContext, TimeProvider timeProvider)
     : MarkdownServiceBase<AzureDevOpsRelease[]>(cakeContext, timeProvider)
 {


### PR DESCRIPTION
# PR: Add Support for Azure DevOps Releases

## Overview

This PR adds full support for processing and documenting Azure DevOps Releases as part of the inventory commands. When running the pipelines or all commands, the tool now retrieves release definitions and generates markdown documentation under the `/Build/Releases` directory.

## Key Changes

- **Models:**  
  - Introduced the `AzureDevOpsRelease` model, which implements `IAzureDevOpsBase` and falls back to the release name when no description is provided.

- **Client Updates:**  
  - Added a new partial class (`AZureDevOpsClient.Releases.cs`) with the `GetReleases` method to fetch release definitions from Azure DevOps.  
  - Supports filtering releases based on include/exclude options.

- **Command Refactoring:**  
  - Updated the main project processing (`InventoryCommand.Projects.cs`) to include release processing.  
  - Moved release-specific logic into its own partial file (`InventoryCommand.Releases.cs`) for better modularity.

- **Markdown Services:**  
  - Created `ReleaseMarkdownService` for generating markdown for individual releases.  
  - Created `ReleasesMarkdownService` for generating an index of releases.  
  - Updated `BuildsMarkdownService` and `ProjectMarkdownService` to output release information in the build documentation.

- **Settings:**  
  - Extended `AZDOISettings`, `AZDOIPipelinesSettings`, and `AZDOIAllSettings` to support new command options for releases (`--include-release` and `--exclude-release`).

- **Tests:**  
  - Added unit tests for the new release markdown services and client release filtering.  
  - Updated inventory command tests to verify that releases are correctly processed and documented.
  - Updated `AzureDevOpsClientTests` to test the new releases client.
  
- **README:**
  - Updated `README.md` to include the new (`--include-release` and `--exclude-release`) parameters.

Fixes #79 